### PR TITLE
Filtering blog posts after switching category #30

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -132,7 +132,14 @@ title: Blog & News
 
 <script>
     function filterPosts(rawSearchQuery) {
+
         markFirstCategoryAsActive();
+
+        const unmatchedPosts = document.getElementsByClassName("hidden");
+        
+        for (let index = 0; index < unmatchedPosts.length; index++) {
+            unmatchedPosts[index].classList.remove("hidden");
+        }
 
         const searchQuery = rawSearchQuery.toLowerCase().trim();
         // console.log(searchQuery);


### PR DESCRIPTION
When the filterPosts function is called the .hidden class is removed from all blog posts before filtering posts based on the search input.

*Edit: Closes #30 